### PR TITLE
Sim script now has support for varying beam FWHM and pointing file is now read in its entirety, but sparser pointing files are now on disk.

### DIFF
--- a/aux/paramfile_sim.py
+++ b/aux/paramfile_sim.py
@@ -1,13 +1,17 @@
 # PARAMETER FILE TO RUN A SIMULATED 
 # DATA CREATION
 
-OUTPUT_FOLDER = 'sim_data_cmb_dust/'
-POINTING_PATH = '/mn/stornext/d5/data/artemba/other/extracted_pointing_no_skip_the_whole_survey_shifted.h5'
+OUTPUT_FOLDER = 'sim_data_cmb_dust_sync_nside64_beam20_noise0.1/'
+POINTING_PATH = '/mn/stornext/d23/cmbco/commander4_shared/aux_data/sim_pointing/planck_pointing_fullsurvey_nside2048_downx1000.h5'
+# There exists downsampled versions of above pointing file, for sparser pointing. Useful if running at lower nsides.
+# The not-downsampled pointing contains 13.6 billion pointings. Make sure NTOD*down is smaller than this,
+# but as Planck only covered the full sky about ~8 times during this, also try and make NTOD*down as close to 13.6 billion as possible.
 
 # general map characteristics
-NSIDE = 256
-NTOD = 12*256**2 * 50
-FWHM = 20 # [arcmin]
+NSIDE = 64
+NTOD = 12*128**2 * 50
+#FWHM = [32.2, 9.6, 4.8, 4.7, 4.3] # [arcmin]
+FWHM = [20.0, 20.0, 20.0, 20.0, 20.0] # [arcmin]
 FREQ = [30, 100, 353, 545, 857] # [GHz]
 pol = False # include (Q,U) polarization
 unit = 'uK_RJ' #'MJ/sr' # or 'uK_RJ'
@@ -23,7 +27,7 @@ As = 2.e-9
 ns = 0.965
 
 # components = ["CMB", "dust", "sync", "corr_noise"]  # Remove components from this list to remove them from simulation.
-components = ["CMB", "dust"]
+components = ["CMB", "dust", "sync"]  # Remove components from this list to remove them from simulation.
 
 # thermal dust parameters
 nu_ref_dust = 857 # [GHz]
@@ -36,6 +40,6 @@ beta_sync = -3.1 # check the preset
 
 # noise parameters
 SIGMA0 = [100, 80, 30, 100, 200] # tod level white noise [uK_RJ] 
-SIGMA_SCALE = 1.0 # scale noise level
+SIGMA_SCALE = 0.1 # scale noise level
 SAMP_FREQ = 180 # sampling frequency [Hz]
 

--- a/aux/save_sim_to_h5.py
+++ b/aux/save_sim_to_h5.py
@@ -15,7 +15,7 @@ def save_to_h5_file(ds, pix, psi, fname=None):
     comm_tod = commander_tod(output_path, "", version, overwrite=True)
 
     if fname is None:
-        hdf_filename = f'tod_sim_{param.NSIDE}_s{param.SIGMA_SCALE}_b{param.FWHM}'
+        hdf_filename = f'tod_sim_{param.NSIDE}_s{param.SIGMA_SCALE}_b{param.FWHM[0]:.0f}'
 
     COMMON_GROUP = "/common"
     HUFFMAN_COMPRESSION = ["huffman", {"dictNum": 1}]


### PR DESCRIPTION
### Varying FWHM in sim script
- I am in the process of adding support for varying FWHM in the global CompSep CG solver. For now support has been added for varying FWHM in the simulation script, specified in the simulation parameter file.

### Changes to pointing reading
- Previously, the pointing file was read in its entirety, and then every Nth point was kept depending on what NTOD was set as. Now it is encouraged to send in a sparse pointing file (reducing memory overhead), because the sim code will now only read the first NTOD elements of that file.
- There has also been added a couple of sanity checks (like every pixel being hit once).
- The simulated component maps are also now also simulated at the target map resolution, instead of always at NSIDE 1024 (but max 1024).