### PR TITLE
CompSep now supports varying beams between detectors

### DIFF
--- a/src/python/data_models/scan_TOD.py
+++ b/src/python/data_models/scan_TOD.py
@@ -6,7 +6,7 @@ class ScanTOD:
         myassert(value.ndim==1, "'value' must be a 1D array")
         myassert(value.dtype==np.float64, "'value' dtype must be np.float64")
         myassert(theta.shape==value.shape and phi.shape==value.shape and psi.shape==value.shape,
-            "shape mismatch between input arrays")
+            f"shape mismatch between input arrays. Theta: {theta.shape}, phi: {phi.shape}, psi: {psi.shape}, value: {value.shape}")
         self._value = value
         self._theta = theta
         self._phi = phi

--- a/src/python/params/param_default.yml
+++ b/src/python/params/param_default.yml
@@ -15,7 +15,12 @@ niter_gibbs: 5
 
 nside: 64
 
-fwhm: 20
+fwhm:
+  - 20.0
+  - 20.0
+  - 20.0
+  - 20.0
+  - 20.0
 
 num_scans: 2001
 


### PR DESCRIPTION
- The component separation CG solver now follows the data model `d = B M a + n`, where the beams (B) are now allowed to vary between detectors. This required switching from M B to B M, as M brings a from components to detectors. However, this also introduced several more SHTs, and the full data model is then `d = Y B Y^-1 M Y a + n`.

- The Ax = b equation that gets solved is then: 
`Y^T M^T Y^-1^T B^T Y^T N^-1 Y B Y^-1 M Y a = Y^T M^T Y^-1^T B^T Y^T N^-1 d`.

- FWHM per channel is specified in the parameter file.