### PR TITLE
Performance improvements to sim script

### DIFF
--- a/aux/make_simple_sim.py
+++ b/aux/make_simple_sim.py
@@ -178,8 +178,13 @@ def get_pointing(npix):
     assert pix.shape[0] == ntod, f"Parameter file ntod {ntod} does not match pixel length {pix.shape[0]}, likely because desired length is longer than entire pointing file."
 
     if params.NSIDE != 2048:
-        vec = hp.pix2vec(2048, pix.astype(int))
-        pix = hp.vec2pix(params.NSIDE, vec[0], vec[1], vec[2])
+        np.random.seed(42)
+        ang = hp.pix2ang(2048, pix.astype(int))
+        ang1 = ang[0] + np.random.uniform(-0.025, 0.025, ang[0].shape)
+        ang2 = ang[1] + np.random.uniform(-0.025, 0.025, ang[1].shape)
+        ang1 = np.clip(ang1, 0, np.pi)
+        ang2 = np.clip(ang2, 0, 2*np.pi)
+        pix = hp.ang2pix(params.NSIDE, ang1, ang2)
 
     return pix.astype('int32')
 

--- a/aux/make_simple_sim.py
+++ b/aux/make_simple_sim.py
@@ -59,10 +59,8 @@ def generate_cmb(freqs, fwhm, units, nside, lmax):
     alms = hp.synalm(Cls, lmax=lmax, new=True)
     print(f"Finished CMB synALMs in {time.time()-t0:.1f}s."); t0 = time.time()
     smooth_alms = np.zeros((len(freqs), 3, hp.Alm.getsize(lmax)), dtype=np.complex128)
-    print(smooth_alms.dtype)
     for i in range(len(freqs)):
         smooth_alms[i] = hp.smoothalm(alms, fwhm=fwhm[i].to('rad').value)
-    print(smooth_alms.dtype)
     print(f"Finished CMB smoothing in {time.time()-t0:.1f}s."); t0 = time.time()
     cmb = np.zeros(12*nside**2, dtype=np.float32)
     cmb = hp.alm2map(alms, nside, pixwin=False)


### PR DESCRIPTION
Optimizations to the simulation creation script:
- The smoothing of each component now happens in alm space.
- The tasks not doing components do not hold an empty copy of the map.
- The 1/f noise generation is now also done per task only on their respective sections of the TOD, lowering memory footprint.
- Implemented a temporary solution to higher nsides than 2048: Add pointing noise to the 2048 pointings, so that not most pixels are never hit.
NB: The changes to the noise generation produce different results (about 3x less noisy data) than before, but I think the new ones are correct. Unsure what was wrong with the old one.