### PR TITLE
New preconditioners, and back to real-alm representation in CG

### DIFF
--- a/src/python/compsep_processing.py
+++ b/src/python/compsep_processing.py
@@ -39,7 +39,7 @@ def init_compsep_processing(CompSep_comm: Comm, params: Bunch) -> tuple[list[Dif
             # getattr loads the class specified by "component_class" from the model.component file.
             # This class is then instantiated with the "params" specified, and appended to the components list.
             if component.params.lmax == "full":
-                component.params.lmax = 3*params.nside-1
+                component.params.lmax = (params.nside*5)//2
             components.append(getattr(component_lib, component.component_class)(component.params))
 
     ### Setting up info for each band, including where to get the data from (map from file, or receive from TOD processing) ###

--- a/src/python/solvers/dense_matrix_math.py
+++ b/src/python/solvers/dense_matrix_math.py
@@ -11,7 +11,6 @@ from mpi4py import MPI
 from mpi4py.MPI import Comm
 import scipy
 from collections.abc import Callable
-from scipy.linalg import svd
 
 
 class DenseMatrix:
@@ -98,7 +97,7 @@ class DenseMatrix:
             Useful for debugging CG preconditioners, as their primary purpose is to improve the condition number.
         """
         if self.is_master:
-            sing_vals = svd(self.A_matrix, compute_uv=False)
+            sing_vals = scipy.linalg.svd(self.A_matrix, compute_uv=False)
             self.logger.info(f"Condition number of matrix {self.matrix_name}: {sing_vals[0]/sing_vals[-1]:.3e}")
             self.logger.info(f"Singular values of matrix {self.matrix_name}: {sing_vals[0]:.1e} .. {sing_vals[sing_vals.size//4]:.1e} .. {sing_vals[sing_vals.size//2]:.1e} .. {sing_vals[3*sing_vals.size//4]:.1e} .. {sing_vals[-1]:.1e}")
 
@@ -113,7 +112,7 @@ class DenseMatrix:
             if is_hermitian:
                 self.logger.info(f"Matrix {self.matrix_name} is Hermitian with mean(A^H - A)/std(A) = {diff:.2e}")
             else:
-                self.logger.warning(f"Matrix {self.matrix_name} is NOT HERMITIAN with mean(A^T - A)/std(A) = {diff:.2e}")
+                self.logger.warning(f"Matrix {self.matrix_name} is NOT HERMITIAN with mean(A^H - A)/std(A) = {diff:.2e}")
 
 
     def print_matrix_diag(self):
@@ -127,6 +126,9 @@ class DenseMatrix:
 
 
     def test_matrix_eigenvalues(self):
+        """ Calculate and print the eigenvalues of the A-matrix.
+            Prints a warning if they do not align with a Hermitian positive definite matrix. 
+        """
         if self.is_master:
             eigvals = scipy.linalg.eigvals(self.A_matrix)
             min_eigval = np.min(np.abs(eigvals))

--- a/src/python/solvers/dense_matrix_math.py
+++ b/src/python/solvers/dense_matrix_math.py
@@ -51,12 +51,12 @@ class DenseMatrix:
         else:
             range_func = range
         my_rank = self.CompSep_comm.Get_rank()
-        self.A_matrix = np.zeros((self.full_size, self.full_size), dtype=np.complex128)
+        self.A_matrix = np.zeros((self.full_size, self.full_size))
         for i in range_func(self.full_size):
             if i >= self.my_start_idx and i < self.my_stop_idx:
-                unit_vec = utils.uvec(self.my_size, i-self.my_start_idx, dtype=np.complex128)
+                unit_vec = utils.uvec(self.my_size, i-self.my_start_idx)
             else:
-                unit_vec = np.zeros(self.my_size, dtype=np.complex128)
+                unit_vec = np.zeros(self.my_size)
             out_vec = self.A_operator(unit_vec)
             if my_rank < self.ncomps:
                 self.A_matrix[i,self.my_start_idx:self.my_stop_idx] = out_vec
@@ -83,7 +83,7 @@ class DenseMatrix:
         if self.is_holding_comp:
             x_bestfit = x_bestfit[self.my_start_idx:self.my_stop_idx]
         else:
-            x_bestfit = np.zeros((0,), dtype=np.complex128)
+            x_bestfit = np.zeros((0,))
         return x_bestfit
 
 

--- a/src/python/solvers/preconditioners.py
+++ b/src/python/solvers/preconditioners.py
@@ -151,12 +151,9 @@ class MixingMatrixPreconditioner:
         if self.is_holding_comp:
             a_map = np.empty((self.compsep.npix,), dtype=np.float64)
             curvedsky.map2alm_healpix(a_map, a_array, niter=3, adjoint=True, spin=0, nthread=self.compsep.params.nthreads_compsep)
-            # print("1", np.min(a_map), np.max(a_map), np.mean(a_map), np.sum(np.isfinite(a_map)))
             a_map_all = self.CompSep_subcomm.allgather(a_map)
             a_map_all = np.array(a_map_all)
-            # print("2", np.min(a_map_all), np.max(a_map_all), np.mean(a_map_all), np.sum(np.isfinite(a_map_all)))
             a_map_all = np.matmul(self.MT_M_inv, a_map_all)
-            # print("3", np.min(a_map_all), np.max(a_map_all), np.mean(a_map_all), np.sum(np.isfinite(a_map_all)))
-            curvedsky.map2alm_healpix(a_map_all, a_array, niter=3, spin=0, nthread=self.compsep.params.nthreads_compsep)
-            a_array = a_array[self.my_comp]
+            a_map_me = a_map_all[self.my_comp]
+            curvedsky.map2alm_healpix(a_map_me, a_array, niter=3, spin=0, nthread=self.compsep.params.nthreads_compsep)
         return a_array

--- a/src/python/solvers/preconditioners.py
+++ b/src/python/solvers/preconditioners.py
@@ -133,7 +133,7 @@ class NoiseOnlyPreconditioner:
         # Convert from real to complex alms, apply the Y^T N^-1 Y matrix, and then convert back.
         a_array_out = alm_real2complex(a_array, self.my_comp_lmax)
         a_array_out /= self.YTNY
-        a_array_out = alm_complex2real(a_array, self.my_comp_lmax)
+        a_array_out = alm_complex2real(a_array_out, self.my_comp_lmax)
         return a_array_out
 
 

--- a/src/python/solvers/preconditioners.py
+++ b/src/python/solvers/preconditioners.py
@@ -5,6 +5,7 @@ from mpi4py import MPI
 import typing
 from numpy.typing import NDArray
 from pixell import curvedsky
+from src.python.utils.math_operations import alm_to_map, alm_to_map_adjoint, alm_real2complex, alm_complex2real
 
 if typing.TYPE_CHECKING:  # Only import when performing type checking, avoiding circular import during normal runtime.
     from src.python.solvers.comp_sep_solvers import CompSepSolver
@@ -43,15 +44,15 @@ class BeamOnlyPreconditioner:
     def __call__(self, a_array: NDArray):
         compsep = self.compsep
         mycomp = compsep.CompSep_comm.Get_rank()
+        all_fwhm = np.array(compsep.CompSep_comm.allgather(self.compsep.my_band_fwhm_rad))
 
         if mycomp >= compsep.ncomp:  # nothing to do
             return a_array
-        a = a_array.copy()  # I'm not sure if the copy is needed
         
         lmax = compsep.lmax_per_comp[mycomp]
         beam_window_squared_sum = np.zeros(lmax + 1)
 
-        for fwhm in compsep.fwhm_rad_allbands:
+        for fwhm in all_fwhm:
             # Create beam window function. Square the beam window since it appears twice in the system matrix
             beam_window_squared = hp.gauss_beam(fwhm, lmax=lmax)**2
                 
@@ -62,9 +63,10 @@ class BeamOnlyPreconditioner:
             # Add up the individual contributions to the beam from each frequency.                
             beam_window_squared_sum += beam_window_squared
         # Apply inverse squared beam (divide by beam window squared)
-        a = hp.almxfl(a, 1.0/beam_window_squared_sum)
-
-        return a
+        a_array_out = alm_real2complex(a_array, self.compsep.my_comp_lmax)
+        a_array_out = hp.almxfl(a_array_out, 1.0/beam_window_squared_sum, inplace=True)
+        a_array_out = alm_complex2real(a_array_out, self.compsep.my_comp_lmax)
+        return a_array_out
 
 
 
@@ -81,26 +83,33 @@ class NoiseOnlyPreconditioner:
         self.compsep = compsep
         mycomp = compsep.CompSep_comm.Get_rank()
 
+        # Since the noise-map has no component-dependence (while the A-matrix does), we simply
+        # have the same weights per component, and use the average of the band-weights.
         w = 1.0/compsep.map_rms**2
-        w_alm = hp.map2alm(w, lmax=compsep.lmax)
-        # MR FIXME: the next two lines look like an expensive no-op to me ...
-        # or is compsep.map_rms different on different tasks?
-        w_alm = compsep.CompSep_comm.allreduce(w_alm, op=MPI.SUM)
-        w_alm /= compsep.CompSep_comm.Get_size()
+        w_alm = None
+        for icomp in range(compsep.ncomp): # The different components have different lmax, so we loop over each.
+            lmax = compsep.lmax_per_comp[icomp]
+            temp_w_alm = hp.map2alm(w, lmax=lmax)  # Create alms at the specific lmax used by this component.
+            if mycomp == icomp:
+                w_alm = compsep.CompSep_comm.reduce(temp_w_alm, op=MPI.SUM, root=icomp)  # Reduce to the rank holding this component.
+                w_alm /= compsep.CompSep_comm.Get_size()
+            else:
+                compsep.CompSep_comm.reduce(temp_w_alm, op=MPI.SUM, root=icomp)  # Reduce to the rank holding this component.
 
         if mycomp >= compsep.ncomp:
             return
 
-        self.YTNY = np.zeros(compsep.alm_len_percomp[mycomp], dtype=np.complex128)
-        lmax = compsep.lmax_per_comp[mycomp]
-        w_alm_only_m0 = np.zeros(lmax + 1, dtype=np.complex128)
-        for l in range(lmax + 1):
-            idx = hp.Alm.getidx(lmax, l, 0)
+        self.my_comp_lmax = compsep.my_comp_lmax
+        my_alm_len_complex = ((self.my_comp_lmax+1)*(self.my_comp_lmax+2))//2  # Not the same as the real-valued alms.
+        self.YTNY = np.zeros(my_alm_len_complex, dtype=np.complex128)
+        w_alm_only_m0 = np.zeros(self.my_comp_lmax + 1, dtype=np.complex128)
+        for l in range(self.my_comp_lmax + 1):
+            idx = hp.Alm.getidx(self.my_comp_lmax, l, 0)
             w_alm_only_m0[l] = w_alm[idx]
 
         inv_sqrt_4pi = 1.0/np.sqrt(4*np.pi)
-        for l in range(lmax + 1):
-            l3_max = min(lmax, 2 * l)
+        for l in range(self.my_comp_lmax + 1):
+            l3_max = min(self.my_comp_lmax, 2 * l)
             for m in range(0, l + 1):
                 l3_arr = np.arange(0, l3_max + 1)
                 l_arr = np.full_like(l3_arr, l)
@@ -109,7 +118,7 @@ class NoiseOnlyPreconditioner:
                 value = (-1)**m*py3nj.wigner3j(2*l_arr, 2*l_arr, 2*l3_arr, 2*m_arr, -2*m_arr, 0) * \
                     py3nj.wigner3j(2*l_arr, 2*l_arr, 2*l3_arr, 0, 0, 0) * w_alm_only_m0[l3_arr] * \
                     np.sqrt((2*l_arr + 1)**2*(2*l3_arr + 1))*inv_sqrt_4pi
-                idx = hp.Alm.getidx(lmax, l, m)
+                idx = hp.Alm.getidx(self.my_comp_lmax, l, m)
                 self.YTNY[idx] += np.sum(value)
         # alm_plotter(self.YTNY[icomp], lmax, filename=f"YTNY_{icomp}.png")
 
@@ -120,8 +129,11 @@ class NoiseOnlyPreconditioner:
 
         if mycomp >= compsep.ncomp:  # nothing to do
             return a_array
-
-        return a_array / self.YTNY
+        # Convert from real to complex alms, apply the Y^T N^-1 Y matrix, and then convert back.
+        a_array_out = alm_real2complex(a_array, self.my_comp_lmax)
+        a_array_out /= self.YTNY
+        a_array_out = alm_complex2real(a_array, self.my_comp_lmax)
+        return a_array_out
 
 
 class MixingMatrixPreconditioner:
@@ -133,7 +145,7 @@ class MixingMatrixPreconditioner:
             M[:,icomp] = comp.get_sed(compsep.freqs)
         MT_M = np.matmul(M.T, M)
         self.MT_M_inv = np.linalg.inv(MT_M)
-
+        print(self.MT_M_inv.shape)
         self.my_comp = compsep.CompSep_comm.Get_rank()
         self.is_holding_comp = self.my_comp < compsep.ncomp
         self.full_size = np.sum(compsep.alm_len_percomp)
@@ -149,11 +161,13 @@ class MixingMatrixPreconditioner:
 
     def __call__(self, a_array: NDArray):
         if self.is_holding_comp:
+            a_array = alm_real2complex(a_array, self.compsep.my_comp_lmax)
             a_map = np.empty((self.compsep.npix,), dtype=np.float64)
-            curvedsky.map2alm_healpix(a_map, a_array, niter=3, adjoint=True, spin=0, nthread=self.compsep.params.nthreads_compsep)
+            curvedsky.alm2map_healpix(a_array, a_map, spin=0, nthread=self.compsep.params.nthreads_compsep)
             a_map_all = self.CompSep_subcomm.allgather(a_map)
             a_map_all = np.array(a_map_all)
             a_map_all = np.matmul(self.MT_M_inv, a_map_all)
             a_map_me = a_map_all[self.my_comp]
             curvedsky.map2alm_healpix(a_map_me, a_array, niter=3, spin=0, nthread=self.compsep.params.nthreads_compsep)
+            a_array = alm_complex2real(a_array, self.compsep.my_comp_lmax)
         return a_array


### PR DESCRIPTION
- Implemented a preconditioner for the mixing matrix, as well as a joint preconditioner which takes all of noise, mixing matrix, and beam into account to some extent. It should be improved in the future, but it's much better than nothing.
- Changed back from complex to real alm representation, which makes it easier to check for the validity of the LHS matrix, because it should now be Hermitian positive definite in the normal dot product space. Also means we don't need specialized dot product in the CG. Disadvantage is that every time we want to do something with the x-vector (such as apply the LHS matrix), we must convert it to complex and then back after.
- Cleaned up and fixed a bug in the dense matrix debug mode for the CG.