### PR TITLE
Dev polarization

### DIFF
--- a/src/python/commander4.py
+++ b/src/python/commander4.py
@@ -87,7 +87,7 @@ def main(params: Bunch, params_dict: dict):
     tod_band_masters_dict = None
     CompSep_band_masters_dict = None
     if color == 0:
-        is_band_master, band_comm, my_band_identifier, tod_band_masters_dict, experiment_data, detector_samples = init_tod_processing(proc_comm, params)
+        is_band_master, band_comm, det_comm, my_band_identifier, tod_band_masters_dict, experiment_data, detector_samples = init_tod_processing(proc_comm, params)
         detector_samples_chain1 = detector_samples
         detector_samples_chain2 = deepcopy(detector_samples)
     elif color == 1:
@@ -102,7 +102,7 @@ def main(params: Bunch, params_dict: dict):
         # Chain #1 do TOD processing, resulting in maps_chain1 (we start with a fake output of component separation, containing a completely empty sky).
         compsep_output_black = get_empty_compsep_output(experiment_data)
 
-        curr_tod_output, detector_samples_chain1 = process_tod(proc_comm, band_comm, experiment_data, detector_samples_chain1, compsep_output_black, params, 1, 1)
+        curr_tod_output, detector_samples_chain1 = process_tod(proc_comm, band_comm, det_comm, experiment_data, detector_samples_chain1, compsep_output_black, params, 1, 1)
         send_tod(is_band_master, curr_tod_output, CompSep_band_masters_dict, my_band_identifier)
         curr_compsep_output = compsep_output_black
 
@@ -120,9 +120,9 @@ def main(params: Bunch, params_dict: dict):
             if proc_comm.Get_rank() == 0:
                 logger.info(f"Worldrank {worldrank}, subrank {proc_comm.Get_rank()} starting TOD iteration {iter_num}.")
             if chain_num == 1:
-                curr_tod_output, detector_samples_chain1 = process_tod(proc_comm, band_comm, experiment_data, detector_samples_chain1, curr_compsep_output, params, chain_num, iter_num)
+                curr_tod_output, detector_samples_chain1 = process_tod(proc_comm, band_comm, det_comm, experiment_data, detector_samples_chain1, curr_compsep_output, params, chain_num, iter_num)
             elif chain_num == 2:
-                curr_tod_output, detector_samples_chain2 = process_tod(proc_comm, band_comm, experiment_data, detector_samples_chain2, curr_compsep_output, params, chain_num, iter_num)
+                curr_tod_output, detector_samples_chain2 = process_tod(proc_comm, band_comm, det_comm, experiment_data, detector_samples_chain2, curr_compsep_output, params, chain_num, iter_num)
             if proc_comm.Get_rank() == 0:
                 logger.info(f"TOD: Rank {proc_comm.Get_rank()} finished chain {chain_num}, iter {iter_num} in {time.time()-t0:.2f}s. Receiving compsep results.")
             curr_compsep_output = receive_compsep(band_comm, my_band_identifier, band_comm.Get_rank()==0, CompSep_band_masters_dict)

--- a/src/python/data_models/detector_TOD.py
+++ b/src/python/data_models/detector_TOD.py
@@ -3,12 +3,12 @@ import numpy as np
 from numpy.typing import NDArray
 
 class DetectorTOD:
-    def __init__(self, scanlist: list[ScanTOD], nu, fwhm, nside, processing_mask_map):
+    def __init__(self, scanlist: list[ScanTOD], nu, fwhm, nside, data_nside):
         self._scanlist = scanlist
         self._nu = nu
         self._fwhm = fwhm
-        self._nside = nside
-        self._processing_mask_map = processing_mask_map
+        self._eval_nside = nside
+        self._data_nside = data_nside
 
     @property
     def nu(self):
@@ -20,11 +20,11 @@ class DetectorTOD:
 
     @property
     def nside(self):
-        return self._nside
+        return self._eval_nside
 
     @property
-    def processing_mask_map(self):
-        return self._processing_mask_map
+    def data_nside(self):
+        return self._data_nside
 
     @property
     def blm(self):

--- a/src/python/data_models/scan_TOD.py
+++ b/src/python/data_models/scan_TOD.py
@@ -13,6 +13,8 @@ class ScanTOD:
         log.logassert_np(tod.dtype in [np.float64,np.float32], "TOD dtype must be floating type,"
                          f" is {tod.dtype}", logger)
         log.logassert_np(orb_dir_vec.size == 3, "orb_dir_vec must be a vector of size 3.", logger)
+        log.logassert_np(processing_mask_map.dtype == bool, "Processing mask is not boolean type",
+                         logger)
         self._tod = tod
         self._pix_encoded = pix_encoded
         self._psi_encoded = psi_encoded
@@ -25,7 +27,6 @@ class ScanTOD:
         self._huffman_tree = huffman_tree
         self._huffman_symbols = huffman_symbols
         self._npsi = npsi
-        log.logassert_np(processing_mask_map.dtype == bool, "asdf", logger)
         self._processing_mask_TOD = np.packbits(processing_mask_map[self.pix])
 
 

--- a/src/python/data_models/scan_TOD.py
+++ b/src/python/data_models/scan_TOD.py
@@ -1,25 +1,33 @@
 import numpy as np
+import healpy as hp
 from output import log
 import logging
 from numpy.typing import NDArray
+from src.python.utils.huffman import Huffman
 
 class ScanTOD:
-    def __init__ (self, tod, pix, psi, startTime, scanID, nside, fsamp, orb_dir_vec):
+    def __init__ (self, tod, pix_encoded, psi_encoded, startTime, scanID, nside, data_nside, fsamp, orb_dir_vec,
+                  huffman_tree, huffman_symbols, npsi, processing_mask_map):
         logger = logging.getLogger(__name__)
         log.logassert_np(tod.ndim==1, "'value' must be a 1D array", logger)
         log.logassert_np(tod.dtype in [np.float64,np.float32], "TOD dtype must be floating type,"
                          f" is {tod.dtype}", logger)
-        log.logassert_np(np.max(pix) < 12*nside**2, f"Largest pixel index {np.max(pix)}"
-                         f"is too large for the specified NSIDE ({nside}).", logger)
         log.logassert_np(orb_dir_vec.size == 3, "orb_dir_vec must be a vector of size 3.", logger)
         self._tod = tod
-        self._pix = pix
-        self._psi = psi
+        self._pix_encoded = pix_encoded
+        self._psi_encoded = psi_encoded
         self._startTime = startTime
         self._scanID = scanID
-        self._nside = nside
+        self._eval_nside = nside
+        self._data_nside = data_nside
         self._fsamp = fsamp
         self._orb_dir_vec = orb_dir_vec
+        self._huffman_tree = huffman_tree
+        self._huffman_symbols = huffman_symbols
+        self._npsi = npsi
+        log.logassert_np(processing_mask_map.dtype == bool, "asdf", logger)
+        self._processing_mask_TOD = np.packbits(processing_mask_map[self.pix])
+
 
     @property
     def nsamples(self) -> int:
@@ -34,21 +42,43 @@ class ScanTOD:
         return self._tod
 
     @property
+    def nside(self):
+        """ The nside this detector should be evalutated at.
+        """
+        return self._eval_nside
+
+    @property
+    def data_nside(self):
+        """ The nside the pixel indices are stored at. This should never explicitly be exposed to
+            the user, but we use this nside for internal conversions. 
+        """
+        return self._data_nside
+
+    @property
     def pix(self) -> NDArray[np.integer]:
-        return self._pix
+        pix = Huffman(tree=self._huffman_tree, symb=self._huffman_symbols).Decoder(self._pix_encoded)
+        if self.nside != self.data_nside:
+            pix = hp.ang2pix(self.nside, *hp.pix2ang(self.data_nside, pix))
+        return pix
 
     @property
     def psi(self) -> NDArray[np.floating]:
-        return self._psi
-
+        psi = Huffman(tree=self._huffman_tree, symb=self._huffman_symbols).Decoder(self._psi_encoded)
+        return 2*np.pi * psi.astype(np.float64)/self._npsi
+        
     @property
     def scanID(self) -> int:
         return self._scanID
     
     @property
-    def nside(self) -> int:
-        return self._nside
-    
+    def processing_mask_TOD(self):
+        mask = np.unpackbits(self._processing_mask_TOD).view(bool)
+        if mask.size > self._tod.size + 7 or mask.size < self._tod.size:
+            # The bytearray is stored in multiples of 8, so it can be up to 7 elements
+            # longer than the TOD. If it's even longer or shorter, something is wrong.
+            raise ValueError(f"Mask size {mask.size} doesn't match TOD size {self._tod.size}.")
+        return mask[:self._tod.size]
+
     @property
     def fsamp(self) -> float:
         return self._fsamp

--- a/src/python/maps_from_file.py
+++ b/src/python/maps_from_file.py
@@ -1,0 +1,71 @@
+import numpy as np
+import healpy as hp
+from pixell.bunch import Bunch
+from src.python.data_models.detector_map import DetectorMap
+from astropy.io import fits
+import logging
+from src.python.output.log import logassert
+import pysm3.units as pysm3_u
+
+
+def read_sim_map_from_file(my_band: Bunch) -> DetectorMap:
+    """To be run once before starting TOD processing.
+
+    Determines whether the process is TOD master, creates the band communicator
+    and determines whether the process is the band master. Also reads the
+    experiment data.
+
+    Input:
+        my_band (Bunch): The section of the parameter file corresponding to this CompSep band, as a "Bunch" type.
+
+    Output:
+        data (list of DetectorMaps): nbands (DetectorMap)
+    """
+    logger = logging.getLogger(__name__)
+    map_signal = hp.read_map(my_band.path_signal_map)
+    map_rms = hp.read_map(my_band.path_rms_map)
+    nside = np.sqrt(map_signal.size//12)
+    logassert(nside.is_integer(), f"Npix dimension of map ({map_signal.size}) resulting in a non-integer nside ({nside}).", logger)
+    nside = int(nside)
+    return DetectorMap(map_signal, None, map_rms, my_band.freq, my_band.fwhm, my_band.nside)
+
+
+def read_Planck_map_from_file(my_band: Bunch) -> DetectorMap:
+    logger = logging.getLogger(__name__)
+    if "WMAP" in str(my_band):
+        # WMAP maps are in mK_CMB
+        map_signal = 1e3*fits.open(my_band.path_signal_map)[1].data["I_Stokes"].flatten().astype(np.float32)
+        map_rms = 1e3*fits.open(my_band.path_rms_map)[1].data["II_Stokes"].flatten().astype(np.float32)  
+        map_rms = np.sqrt(map_rms)
+    elif "857" in str(my_band):
+        # I think HFI maps are in uK_CMB
+        map_signal = fits.open(my_band.path_signal_map)[1].data["TEMPERATURE"].flatten().astype(np.float32)
+        map_rms = fits.open(my_band.path_rms_map)[1].data["TEMPERATURE"].flatten().astype(np.float32)
+        map_signal = hp.reorder(map_signal, inp="NEST", out="RING")
+        map_rms = hp.reorder(map_rms, inp="NEST", out="RING")
+    else:
+        # I think Haslam is in uK_CMB
+        map_signal = fits.open(my_band.path_signal_map)[1].data["TEMPERATURE"].flatten().astype(np.float32)
+        map_rms = fits.open(my_band.path_rms_map)[1].data["TEMPERATURE"].flatten().astype(np.float32)
+
+    map_signal = map_signal * pysm3_u.uK_CMB
+    map_signal = map_signal.to(pysm3_u.uK_RJ, equivalencies=pysm3_u.cmb_equivalencies(my_band.freq*pysm3_u.GHz)).value
+    map_rms = map_rms * pysm3_u.uK_CMB
+    map_rms = map_rms.to(pysm3_u.uK_RJ, equivalencies=pysm3_u.cmb_equivalencies(my_band.freq*pysm3_u.GHz)).value
+
+    nside = np.sqrt(map_signal.size//12)
+    logassert(nside.is_integer(), f"Npix dimension of map ({map_signal.size}) resulting in a non-integer nside ({nside}).", logger)
+    nside = int(nside)
+
+    if nside != 512:
+        map_signal = hp.ud_grade(map_signal, 512)
+        map_rms = hp.ud_grade(map_rms, 512)
+        nside = 512
+
+    detmap = DetectorMap(map_signal, np.zeros_like(map_signal, dtype=np.float32), map_rms, my_band.freq, my_band.fwhm, nside)
+    detmap.g0 = 0.0
+    detmap.gain = 0.0
+    detmap.skysub_map = np.zeros_like(map_signal, dtype=np.float32)
+    detmap.rawobs_map = np.zeros_like(map_signal, dtype=np.float32)
+    detmap.orbdipole_map = np.zeros_like(map_signal, dtype=np.float32)
+    return detmap

--- a/src/python/tod_processing_Planck.py
+++ b/src/python/tod_processing_Planck.py
@@ -25,12 +25,12 @@ def get_processing_mask(my_band: Bunch) -> DetectorTOD:
     return mask
 
 
-def read_Planck_TOD_data(database_filename: str, my_band: Bunch, params: Bunch, scan_idx_start: int, scan_idx_stop: int) -> DetectorTOD:
+def read_Planck_TOD_data(database_filename: str, my_band: Bunch, my_det: Bunch, params: Bunch, my_detector_id: int, scan_idx_start: int, scan_idx_stop: int) -> tuple[DetectorTOD, DetectorSamples]:
     logger = logging.getLogger(__name__)
-
     oids = []
     pids = []
     filenames = []
+    detname = my_det.name
     with open(database_filename + f"filelist_{my_band.freq_identifier:02d}.txt") as infile:
         infile.readline()
         for line in infile:
@@ -41,20 +41,27 @@ def read_Planck_TOD_data(database_filename: str, my_band: Bunch, params: Bunch, 
     com_tod = commander_tod(database_filename, "LFI")
     scanlist = []
     num_included = 0
-    if my_band.freq_identifier == 30:
-        detname = "27"
-        local_nside = 512
-    elif my_band.freq_identifier == 44:
-        detname = "24"
-        local_nside = 512
-    elif my_band.freq_identifier == 70:
-        detname = "18"
+    # if my_band.freq_identifier == 30:
+    #     detname = "27"
+    #     local_nside = 512
+    # elif my_band.freq_identifier == 44:
+    #     detname = "24"
+    #     local_nside = 512
+    # elif my_band.freq_identifier == 70:
+    #     detname = "18"
+    #     local_nside = 1024
+    if my_band.freq_identifier == 70:
         local_nside = 1024
+    else:
+        local_nside = 512
+        
     if my_band.freq_identifier == 70 and scan_idx_stop >= 45850:
+        print("HELLO", detname)
         from tqdm import trange
         myrange = trange
     else:
         myrange = range
+    print(my_band.freq, detname, scan_idx_start, scan_idx_stop)
 
     bad_PIDs = np.load("/mn/stornext/d23/cmbco/jonas/c4_testing/Commander4/badPIDs.npy")
     previous_oid = -999999
@@ -65,29 +72,29 @@ def read_Planck_TOD_data(database_filename: str, my_band: Bunch, params: Bunch, 
             continue
         if oid != previous_oid:  # Only open file if it's not the same file as the last PID.
             com_tod.init_file(f"{my_band.freq_identifier:03d}", oid)
-        flag_M = com_tod.decompress(f"/{pid}/{detname}M/flag/", compression="huffman")
-        flag_S = com_tod.decompress(f"/{pid}/{detname}S/flag/", compression="huffman")
-        pix_M = com_tod.decompress(f"/{pid}/{detname}M/pix/", compression="huffman").astype(np.uint32)
-        tod_M = com_tod.decompress(f"/{pid}/{detname}M/tod/")[()].astype(np.float32)
-        tod_S = com_tod.decompress(f"/{pid}/{detname}S/tod/")[()].astype(np.float32)
+        flag = com_tod.decompress(f"/{pid}/{detname}/flag/", compression="huffman")
+        npsi = com_tod.decompress("/common/npsi/")[()]
+        pix = com_tod.decompress(f"/{pid}/{detname}/pix/", compression="huffman").astype(np.uint32)
+        psi = com_tod.decompress(f"/{pid}/{detname}/psi/", compression="huffman").astype(np.float32)
+        psi = 2*np.pi * psi/npsi  # Convert
+        tod = com_tod.decompress(f"/{pid}/{detname}/tod/")[()].astype(np.float32)
+        # tod_S = com_tod.decompress(f"/{pid}/{detname}S/tod/")[()].astype(np.float32)
         # This is the orbital velocity relative to the sun, in galactic coordinates:
         vsun = com_tod.decompress(f"/{pid}/common/vsun/")[()]
         fsamp = com_tod.decompress("/common/fsamp/")[()]
         if local_nside != my_band.nside:
-            pix_M = hp.ang2pix(my_band.nside, *hp.pix2ang(local_nside, pix_M)).astype(np.uint32)
-        mask = ((flag_M & flag_S) & 6111232) == 0
+            pix = hp.ang2pix(my_band.nside, *hp.pix2ang(local_nside, pix)).astype(np.uint32)
+        mask = ((flag) & 6111232) == 0
         if mask.all():
-            tod = (tod_M + tod_S)/2.0
             if np.mean(np.abs(tod)) < 0.001 and np.std(tod) < 0.001:  # Check for crazy data.
-                scanlist.append(ScanTOD(tod, pix_M, np.zeros_like(tod, dtype=np.float32), 0.,
-                                        pid, my_band.nside, fsamp, vsun))
+                scanlist.append(ScanTOD(tod, pix, psi, 0., pid, my_band.nside, fsamp, vsun))
                 num_included += 1
     logger.info(f"Fraction of scans included for {my_band.freq_identifier}: "
                 f"{num_included/(scan_idx_stop-scan_idx_start)*100:.1f} %")
 
     processing_mask_map = get_processing_mask(my_band)
     det_static = DetectorTOD(scanlist, float(my_band.freq), my_band.fwhm, my_band.nside, processing_mask_map)
-    det_static.detector_id = my_band.detector_id
+    det_static.detector_id = my_detector_id
 
     scansample_list = []
     for iscan in range(num_included):
@@ -96,7 +103,8 @@ def read_Planck_TOD_data(database_filename: str, my_band: Bunch, params: Bunch, 
         scansample_list[-1].rel_gain_est = my_band.rel_gain_est
         scansample_list[-1].gain_est = my_band.rel_gain_est + params.initial_g0
     det_samples = DetectorSamples(scansample_list)
-    det_samples.detector_id = my_band.detector_id
+    det_samples.detector_id = my_detector_id
     det_samples.g0_est = params.initial_g0
+    det_samples.detname = detname
 
     return det_static, det_samples

--- a/src/python/tod_processing_Planck.py
+++ b/src/python/tod_processing_Planck.py
@@ -20,7 +20,7 @@ def get_processing_mask(my_band: Bunch) -> DetectorTOD:
     hdul = fits.open(my_band.processing_mask)
     mask = hdul[1].data["TEMPERATURE"].flatten().astype(bool)
     nside = np.sqrt(mask.size//12)
-    if nside != my_band.nside:
+    if nside != my_band.eval_nside:
         mask = hp.ud_grade(mask.astype(np.float64), 512) == 1
     return mask
 
@@ -41,31 +41,12 @@ def read_Planck_TOD_data(database_filename: str, my_band: Bunch, my_det: Bunch, 
     com_tod = commander_tod(database_filename, "LFI")
     scanlist = []
     num_included = 0
-    # if my_band.freq_identifier == 30:
-    #     detname = "27"
-    #     local_nside = 512
-    # elif my_band.freq_identifier == 44:
-    #     detname = "24"
-    #     local_nside = 512
-    # elif my_band.freq_identifier == 70:
-    #     detname = "18"
-    #     local_nside = 1024
-    if my_band.freq_identifier == 70:
-        local_nside = 1024
-    else:
-        local_nside = 512
-        
-    if my_band.freq_identifier == 70 and scan_idx_stop >= 45850:
-        print("HELLO", detname)
-        from tqdm import trange
-        myrange = trange
-    else:
-        myrange = range
-    print(my_band.freq, detname, scan_idx_start, scan_idx_stop)
+    
+    processing_mask_map = get_processing_mask(my_band)
 
     bad_PIDs = np.load("/mn/stornext/d23/cmbco/jonas/c4_testing/Commander4/badPIDs.npy")
     previous_oid = -999999
-    for i_pid in myrange(scan_idx_start, scan_idx_stop):
+    for i_pid in range(scan_idx_start, scan_idx_stop):
         pid = pids[i_pid]
         oid = oids[i_pid]
         if pid in bad_PIDs:
@@ -74,26 +55,24 @@ def read_Planck_TOD_data(database_filename: str, my_band: Bunch, my_det: Bunch, 
             com_tod.init_file(f"{my_band.freq_identifier:03d}", oid)
         flag = com_tod.decompress(f"/{pid}/{detname}/flag/", compression="huffman")
         npsi = com_tod.decompress("/common/npsi/")[()]
-        pix = com_tod.decompress(f"/{pid}/{detname}/pix/", compression="huffman").astype(np.uint32)
-        psi = com_tod.decompress(f"/{pid}/{detname}/psi/", compression="huffman").astype(np.float32)
-        psi = 2*np.pi * psi/npsi  # Convert
+        pix_encoded = com_tod.decompress(f"/{pid}/{detname}/pix/")[()]
+        psi_encoded = com_tod.decompress(f"/{pid}/{detname}/psi/")[()]
+        huffman_tree = com_tod.load_field(f"/{pid}/common/hufftree")[()]
+        huffman_symbols = com_tod.load_field(f"/{pid}/common/huffsymb")[()]
         tod = com_tod.decompress(f"/{pid}/{detname}/tod/")[()].astype(np.float32)
-        # tod_S = com_tod.decompress(f"/{pid}/{detname}S/tod/")[()].astype(np.float32)
         # This is the orbital velocity relative to the sun, in galactic coordinates:
         vsun = com_tod.decompress(f"/{pid}/common/vsun/")[()]
         fsamp = com_tod.decompress("/common/fsamp/")[()]
-        if local_nside != my_band.nside:
-            pix = hp.ang2pix(my_band.nside, *hp.pix2ang(local_nside, pix)).astype(np.uint32)
-        mask = ((flag) & 6111232) == 0
+        mask = (flag & 6111232) == 0
         if mask.all():
             if np.mean(np.abs(tod)) < 0.001 and np.std(tod) < 0.001:  # Check for crazy data.
-                scanlist.append(ScanTOD(tod, pix, psi, 0., pid, my_band.nside, fsamp, vsun))
+                scanlist.append(ScanTOD(tod, pix_encoded, psi_encoded, 0., pid, my_band.eval_nside, my_band.data_nside,
+                                        fsamp, vsun, huffman_tree, huffman_symbols, npsi, processing_mask_map))
                 num_included += 1
     logger.info(f"Fraction of scans included for {my_band.freq_identifier}: "
                 f"{num_included/(scan_idx_stop-scan_idx_start)*100:.1f} %")
 
-    processing_mask_map = get_processing_mask(my_band)
-    det_static = DetectorTOD(scanlist, float(my_band.freq), my_band.fwhm, my_band.nside, processing_mask_map)
+    det_static = DetectorTOD(scanlist, float(my_band.freq), my_band.fwhm, my_band.eval_nside, my_band.data_nside)
     det_static.detector_id = my_detector_id
 
     scansample_list = []

--- a/src/python/utils/map_utils.py
+++ b/src/python/utils/map_utils.py
@@ -6,21 +6,20 @@ from src.python.data_models.detector_TOD import DetectorTOD
 from numpy.typing import NDArray
 
 
-def get_sky_model_TOD(scan: ScanTOD, det_compsep_map: NDArray) -> DetectorTOD:
-    """Projects the current sky-model at our band frequency (in uK_RJ, without gain) into the
-       specified scan pointing. The sky model does not include the orbital dipole.
+def get_static_sky_TOD(det_compsep_map: NDArray[np.floating], pix: NDArray[np.integer]) -> DetectorTOD:
+    """ Projects the current sky-model at our band frequency (in uK_RJ, without gain) into the
+        specified scan pointing. The sky model does not include the orbital dipole.
     """
-    return det_compsep_map[scan.pix]
+    return det_compsep_map[pix]
 
 
-def calculate_s_orb(scan: ScanTOD, experiment: DetectorTOD) -> NDArray:
+def get_s_orb_TOD(scan: ScanTOD, experiment: DetectorTOD, pix: NDArray[np.integer]) -> NDArray:
     T_CMB = 2.725 * 1e6  # CMB temperature in uK_CMB units.
     C = 299792458  # m/s (Speed of light)
-
     # Precomputing the conversion factor from 1 uK_CMB to 1 uK_RJ (not that this conversion is only valid for temperatures close to the CMB).
     uK_CMB_to_uK_RJ = (1*pysm3_u.uK_CMB).to(pysm3_u.uK_RJ, equivalencies=pysm3_u.cmb_equivalencies(experiment.nu*pysm3_u.GHz)).value
 
-    theta, phi = hp.pix2ang(experiment.nside, scan.pix)
+    theta, phi = hp.pix2ang(experiment.nside, pix)
     LOS_vec = hp.ang2vec(theta, phi)
     dot_product = np.sum(scan.orb_dir_vec * LOS_vec, axis=-1)  # How much do the LOS and orbital velocity align?
     s_orb = T_CMB * dot_product / C  # The orbital dipole in units of uK_CMB.

--- a/src/python/utils/mapmaker.py
+++ b/src/python/utils/mapmaker.py
@@ -6,7 +6,7 @@ from pixell import bunch
 import pysm3.units as pysm3_u
 
 from src.python.data_models.detector_TOD import DetectorTOD
-from src.python.utils.map_utils import get_sky_model_TOD, calculate_s_orb
+from src.python.utils.map_utils import get_static_sky_TOD, get_s_orb_TOD
 
 current_dir_path = os.path.dirname(os.path.realpath(__file__))
 src_dir_path = os.path.abspath(os.path.join(os.path.join(current_dir_path, os.pardir), os.pardir))
@@ -86,10 +86,10 @@ def single_det_map_accumulator(det_static: DetectorTOD, det_cs_map: np.array, sa
         raw_tod = scan.tod
         pix = scan.pix
         ntod = raw_tod.shape[0]
-        s_orb = calculate_s_orb(scan, det_static)
+        s_orb = get_s_orb_TOD(scan, det_static, pix)
         inv_var = 1.0/scanparams.sigma0**2
         gain = scanparams.gain_est
-        sky_subtracted_TOD = raw_tod - gain*get_sky_model_TOD(scan, det_cs_map)
+        sky_subtracted_TOD = raw_tod - gain*get_static_sky_TOD(det_cs_map, pix)
         # detmap_signal += np.bincount(pix, weights=scan_map/sigma0**2, minlength=npix)
         # detmap_inv_var += np.bincount(pix, minlength=npix)/sigma0**2
         maplib.map_weight_accumulator(detmap_hits, 1.0, pix.astype(np.int64), ntod, npix)
@@ -142,11 +142,11 @@ def single_det_map_accumulator_IQU(det_static: DetectorTOD, det_cs_map: np.array
         pix = scan.pix
         psi = scan.psi
         ntod = raw_tod.shape[0]
-        s_orb = calculate_s_orb(scan, det_static)
+        s_orb = get_s_orb_TOD(scan, det_static, pix)
         inv_var = 1.0/scanparams.sigma0**2
         gain = scanparams.gain_est
         n_corr = scanparams.n_corr_est
-        sky_subtracted_TOD = raw_tod - gain*get_sky_model_TOD(scan, det_cs_map)
+        sky_subtracted_TOD = raw_tod - gain*get_static_sky_TOD(det_cs_map, pix)
         maplib.map_weight_accumulator(detmap_hits, 1.0, pix.astype(np.int64), ntod, npix)
         maplib.map_weight_accumulator_IQU(detmap_inv_var, (inv_var).astype(np.float64), pix.astype(np.int64), psi.astype(np.float64), ntod, npix)
         maplib.map_accumulator_IQU(detmap_rawobs, (raw_tod/gain).astype(np.float64), inv_var, pix.astype(np.int64), psi.astype(np.float64), ntod, npix)


### PR DESCRIPTION
- Split up band and detectors into two layers in the MPI hierarchy. The parameter file now specifies every detector of a band. There is now also a separate communicator for each detector.
- The relative and temporal gain sampling which previously used the band-communicator now use the detector-communicator, since their stuff is supposed to be solved per-detector.
- The mapmaker keeps the band-communicator, since we for the moment assume maps should always be created from all detectors on a band.
- Switched the I mapmaker for the IQU mapmaker, which seems to work. However, we still throw away Q and U for the moment.