### PR TITLE
Dev compsep speedups

### DIFF
--- a/src/python/mpi_management.py
+++ b/src/python/mpi_management.py
@@ -54,6 +54,8 @@ def init_mpi(params):
         os.environ["MKL_NUM_THREADS"] = f"{params.nthreads_tod}"
         os.environ["VECLIB_MAXIMUM_THREADS"] = f"{params.nthreads_tod}"
         os.environ["NUMEXPR_NUM_THREADS"] = f"{params.nthreads_tod}"
+        import numba
+        numba.set_num_threads(1)
     elif worldrank < params.MPI_config.ntask_tod + params.MPI_config.ntask_compsep:
         if params.betzy_mode:  # Betzy doesn't like heterogeneous MPI setups, so we oversubscribe
                                # the compsep ranks with cores we will in practice use as threads.
@@ -76,7 +78,9 @@ def init_mpi(params):
         os.environ["VECLIB_MAXIMUM_THREADS"] = f"{nthreads_compsep}"
         os.environ["NUMEXPR_NUM_THREADS"] = f"{nthreads_compsep}"
         import numba
-        numba.set_num_threads(nthreads_compsep)
+        # Testing revealed 24 to be a good number (regardless of nside), but I tested this on the
+        # new 384-core nodes, the optimal number is probably slightly lower on the older owls.
+        numba.set_num_threads(min(24,nthreads_compsep))
 
     tot_num_experiment_bands = sum([len(params.experiments[experiment].bands) for experiment in
                                     params.experiments if params.experiments[experiment].enabled])

--- a/src/python/sky_models/component.py
+++ b/src/python/sky_models/component.py
@@ -81,11 +81,6 @@ class DiffuseComponent(Component):
         ells = np.arange(self.lmax + 1)
         prior_amplitude = self.smoothing_prior_amplitude
         prior_exponential = -ells * (ells + 1) * sigma**2
-        if np.abs(prior_exponential[-1]) > 50:
-            logger = logging.getLogger(__name__)
-            logger.warning(f"Exponent in smoothing prior goes up to {prior_exponential[-1]:.4e} "
-                           f"for {self.longname} with lmax {self.lmax} and smoothing prior FWHM = "
-                           f"{self.smoothing_prior_FWHM}rad. CG will likely be unstable.")
         return prior_amplitude * np.exp(prior_exponential)
 
     @property

--- a/src/python/solvers/CG_driver.py
+++ b/src/python/solvers/CG_driver.py
@@ -5,73 +5,57 @@ def default_M(x):     return np.copy(x)
 def default_dot(a,b): return a.dot(np.conj(b))
 
 class distributed_CG:
-	"""Preconditioner borrowed from pixell.utils, and modified to accomodate both the distributed
-	computations of Commander4 component separation, and overriding of certain Numpy operations.
-	"""
-	def __init__(self, A, b, is_master, x0=None, M=default_M, dot=default_dot, destroy_b=False):
-		"""Initialize a solver for the system Ax=b, with a starting guess of x0 (0
-		if not provided). Vectors b and x0 must provide addition and multiplication,
-		as well as the .copy() method, such as provided by numpy arrays. The
-		preconditioner is given by M. A and M must be functors acting on vectors
-		and returning vectors. The dot product may be manually specified using the
-		dot argument. This is useful for MPI-parallelization, for example."""
-		self.is_master = is_master
-		self.logger = logging.getLogger(__name__)
-		self.A   = A
-		self.M   = M
-		self.dot = dot
-		self.b   = b
+    """Preconditioner borrowed from pixell.utils, and modified to accomodate both the distributed
+    computations of Commander4 component separation, and overriding of certain Numpy operations.
+    """
+    def __init__(self, A, b, is_master, x0=None, M=default_M, dot=default_dot, destroy_b=False):
+        """Initialize a solver for the system Ax=b, with a starting guess of x0 (0
+        if not provided). Vectors b and x0 must provide addition and multiplication,
+        as well as the .copy() method, such as provided by numpy arrays. The
+        preconditioner is given by M. A and M must be functors acting on vectors
+        and returning vectors. The dot product may be manually specified using the
+        dot argument. This is useful for MPI-parallelization, for example."""
+        self.is_master = is_master
+        self.logger = logging.getLogger(__name__)
+        self.A   = A
+        self.M   = M
+        self.dot = dot
+        self.b   = b
 
-		# CG meta-parameters
-		self.err = np.inf
-		self.i   = 0
-		if x0 is None:
-			self.x = b.copy()
-			self.r = b.copy() if not destroy_b else b
-		else:
-			self.x  = x0.copy()
-			self.r  = [_b - _Ax for _b,_Ax in zip(b,self.A(self.x))]
-		if is_master:  # Only the master needs these.
-			# Internal work variables
-			z = self.M(self.r)
-			self.rz  = self.dot(self.r, z)  # Avoid calling custom dot func on non-master ranks.
-			self.rz0 = float(self.rz)
-			self.p   = z
-		else:
-			self.p = np.zeros_like(b)
-	def step(self):
-		"""Take a single step in the iteration. Results in .x, .i
-		and .err being updated. To solve the system, call step() in
-		a loop until you are satisfied with the accuracy. The result
-		can then be read off from .x."""
-		# Full vectors: p, Ap, x, r, z. Ap and z not in memory at the
-		# same time. Total memory cost: 4 vectors + 1 temporary = 5 vectors
-		Ap = self.A(self.p)
-		if self.is_master:  # The rest of the CG iteration is done by the master alone.
-			alpha = self.rz/self.dot(self.p, Ap)
-			self.x = [_x + alpha*_p for _x, _p in zip(self.x, self.p)]
-			self.r = [_r - alpha*_Ap for _r, _Ap in zip(self.r, Ap)]
-			del Ap
-			z       = self.M(self.r)
-			next_rz = self.dot(self.r, z)
-			self.err = next_rz/self.rz0
-			beta = next_rz/self.rz
-			self.rz = next_rz
-			self.p = [_p*beta + _z for _p, _z in zip(self.p, z)]
-			self.p_before = self.p.copy()
-		self.i += 1
-	def save(self, fname):
-		"""Save the volatile internal parameters to hdf file fname. Useful
-		for later restoring cg iteration"""
-		import h5py
-		with h5py.File(fname, "w") as hfile:
-			for key in ["i","rz","rz0","x","r","p","err"]:
-				hfile[key] = getattr(self, key)
-	def load(self, fname):
-		"""Load the volatile internal parameters from the hdf file fname.
-		Useful for restoring a saved cg state, after first initializing the
-		object normally."""
-		import h5py
-		with h5py.File(fname, "r") as hfile:
-			for key in ["i","rz","rz0","x","r","p","err"]:
-				setattr(self, key, hfile[key][()])
+        # CG meta-parameters
+        self.err = np.inf
+        self.i   = 0
+        if x0 is None:
+            self.x = b.copy()
+            self.r = b.copy() if not destroy_b else b
+        else:
+            self.x  = x0.copy()
+            self.r  = [_b - _Ax for _b,_Ax in zip(b,self.A(self.x))]
+        if is_master:  # Only the master needs these.
+            # Internal work variables
+            z = self.M(self.r)
+            self.rz  = self.dot(self.r, z)  # Avoid calling custom dot func on non-master ranks.
+            self.rz0 = float(self.rz)
+            self.p   = z
+        else:
+            self.p = []
+    def step(self):
+        """Take a single step in the iteration. Results in .x, .i
+        and .err being updated. To solve the system, call step() in
+        a loop until you are satisfied with the accuracy. The result
+        can then be read off from .x."""
+        # Full vectors: p, Ap, x, r, z. Ap and z not in memory at the
+        # same time. Total memory cost: 4 vectors + 1 temporary = 5 vectors
+        Ap = self.A(self.p)
+        if self.is_master:  # The rest of the CG iteration is done by the master alone.
+            alpha = self.rz/self.dot(self.p, Ap)
+            self.x = [_x + alpha*_p for _x, _p in zip(self.x, self.p)]
+            self.r = [_r - alpha*_Ap for _r, _Ap in zip(self.r, Ap)]
+            del Ap
+            z       = self.M(self.r)
+            next_rz = self.dot(self.r, z)
+            self.err = next_rz/self.rz0
+            beta = next_rz/self.rz
+            self.rz = next_rz
+            self.p = [_p*beta + _z for _p, _z in zip(self.p, z)]
+        self.i += 1

--- a/src/python/solvers/CG_driver.py
+++ b/src/python/solvers/CG_driver.py
@@ -1,0 +1,69 @@
+import numpy as np
+
+def default_M(x):     return np.copy(x)
+def default_dot(a,b): return a.dot(np.conj(b))
+
+class CG:
+	"""Preconditioner borrowed from pixell.utils, and modified to accomodate both the distributed
+    computations of Commander4 component separation, and overriding of certain Numpy operations.
+	"""
+	def __init__(self, A, b, x0=None, M=default_M, dot=default_dot, destroy_b=False):
+		"""Initialize a solver for the system Ax=b, with a starting guess of x0 (0
+		if not provided). Vectors b and x0 must provide addition and multiplication,
+		as well as the .copy() method, such as provided by numpy arrays. The
+		preconditioner is given by M. A and M must be functors acting on vectors
+		and returning vectors. The dot product may be manually specified using the
+		dot argument. This is useful for MPI-parallelization, for example."""
+		# Init parameters
+		self.A   = A
+		self.b   = b # not necessary to store this. Delete?
+		self.M   = M
+		self.dot = dot
+		if x0 is None:
+			self.x = np.zeros_like(b)
+			self.r = b.copy() if not destroy_b else b
+		else:
+			self.x  = x0.copy()
+			self.r  = b-self.A(self.x)
+		# Internal work variables
+		n = b.size
+		z = self.M(self.r)
+		self.rz  = self.dot(self.r, z)
+		self.rz0 = float(self.rz)
+		self.p   = z
+		self.i   = 0
+		self.err = np.inf
+	def step(self):
+		"""Take a single step in the iteration. Results in .x, .i
+		and .err being updated. To solve the system, call step() in
+		a loop until you are satisfied with the accuracy. The result
+		can then be read off from .x."""
+		# Full vectors: p, Ap, x, r, z. Ap and z not in memory at the
+		# same time. Total memory cost: 4 vectors + 1 temporary = 5 vectors
+		Ap = self.A(self.p)
+		alpha = self.rz/self.dot(self.p, Ap)
+		self.x += alpha*self.p
+		self.r -= alpha*Ap
+		del Ap
+		z       = self.M(self.r)
+		next_rz = self.dot(self.r, z)
+		self.err = next_rz/self.rz0
+		beta = next_rz/self.rz
+		self.rz = next_rz
+		self.p  = z + beta*self.p
+		self.i += 1
+	def save(self, fname):
+		"""Save the volatile internal parameters to hdf file fname. Useful
+		for later restoring cg iteration"""
+		import h5py
+		with h5py.File(fname, "w") as hfile:
+			for key in ["i","rz","rz0","x","r","p","err"]:
+				hfile[key] = getattr(self, key)
+	def load(self, fname):
+		"""Load the volatile internal parameters from the hdf file fname.
+		Useful for restoring a saved cg state, after first initializing the
+		object normally."""
+		import h5py
+		with h5py.File(fname, "r") as hfile:
+			for key in ["i","rz","rz0","x","r","p","err"]:
+				setattr(self, key, hfile[key][()])

--- a/src/python/solvers/CG_driver.py
+++ b/src/python/solvers/CG_driver.py
@@ -3,7 +3,7 @@ import numpy as np
 def default_M(x):     return np.copy(x)
 def default_dot(a,b): return a.dot(np.conj(b))
 
-class CG:
+class distributed_CG:
 	"""Preconditioner borrowed from pixell.utils, and modified to accomodate both the distributed
     computations of Commander4 component separation, and overriding of certain Numpy operations.
 	"""

--- a/src/python/solvers/CG_driver.py
+++ b/src/python/solvers/CG_driver.py
@@ -1,5 +1,6 @@
 import numpy as np
 import logging
+from src.python.utils.math_operations import inplace_almlist_add_scaled_array, inplace_almlist_scale_and_add
 
 def default_M(x):     return np.copy(x)
 def default_dot(a,b): return a.dot(np.conj(b))
@@ -26,7 +27,7 @@ class distributed_CG:
         self.err = np.inf
         self.i   = 0
         if x0 is None:
-            self.x = b.copy()
+            self.x = [np.zeros_like(_b) for _b in b]
             self.r = b.copy() if not destroy_b else b
         else:
             self.x  = x0.copy()
@@ -49,13 +50,20 @@ class distributed_CG:
         Ap = self.A(self.p)
         if self.is_master:  # The rest of the CG iteration is done by the master alone.
             alpha = self.rz/self.dot(self.p, Ap)
-            self.x = [_x + alpha*_p for _x, _p in zip(self.x, self.p)]
-            self.r = [_r - alpha*_Ap for _r, _Ap in zip(self.r, Ap)]
+
+            # Line below equivalent to: self.x = [_x + alpha*_p for _x, _p in zip(self.x, self.p)]
+            inplace_almlist_add_scaled_array(self.x, self.p, alpha)
+
+            # Line below equivalent to: self.r = [_r - alpha*_Ap for _r, _Ap in zip(self.r, Ap)]
+            inplace_almlist_add_scaled_array(self.r, Ap, -alpha)
+
             del Ap
             z       = self.M(self.r)
             next_rz = self.dot(self.r, z)
             self.err = next_rz/self.rz0
             beta = next_rz/self.rz
             self.rz = next_rz
-            self.p = [_p*beta + _z for _p, _z in zip(self.p, z)]
+
+            # Line below equivalent to: self.p = [_p*beta + _z for _p, _z in zip(self.p, z)]
+            inplace_almlist_scale_and_add(self.p, z, beta)
         self.i += 1

--- a/src/python/solvers/CG_driver.py
+++ b/src/python/solvers/CG_driver.py
@@ -1,38 +1,44 @@
 import numpy as np
+import logging
 
 def default_M(x):     return np.copy(x)
 def default_dot(a,b): return a.dot(np.conj(b))
 
 class distributed_CG:
 	"""Preconditioner borrowed from pixell.utils, and modified to accomodate both the distributed
-    computations of Commander4 component separation, and overriding of certain Numpy operations.
+	computations of Commander4 component separation, and overriding of certain Numpy operations.
 	"""
-	def __init__(self, A, b, x0=None, M=default_M, dot=default_dot, destroy_b=False):
+	def __init__(self, A, b, is_master, x0=None, M=default_M, dot=default_dot, destroy_b=False):
 		"""Initialize a solver for the system Ax=b, with a starting guess of x0 (0
 		if not provided). Vectors b and x0 must provide addition and multiplication,
 		as well as the .copy() method, such as provided by numpy arrays. The
 		preconditioner is given by M. A and M must be functors acting on vectors
 		and returning vectors. The dot product may be manually specified using the
 		dot argument. This is useful for MPI-parallelization, for example."""
-		# Init parameters
+		self.is_master = is_master
+		self.logger = logging.getLogger(__name__)
 		self.A   = A
-		self.b   = b # not necessary to store this. Delete?
 		self.M   = M
 		self.dot = dot
+		self.b   = b
+
+		# CG meta-parameters
+		self.err = np.inf
+		self.i   = 0
 		if x0 is None:
 			self.x = np.zeros_like(b)
 			self.r = b.copy() if not destroy_b else b
 		else:
 			self.x  = x0.copy()
 			self.r  = b-self.A(self.x)
-		# Internal work variables
-		n = b.size
-		z = self.M(self.r)
-		self.rz  = self.dot(self.r, z)
-		self.rz0 = float(self.rz)
-		self.p   = z
-		self.i   = 0
-		self.err = np.inf
+		if is_master:  # Only the master needs these.
+			# Internal work variables
+			z = self.M(self.r)
+			self.rz  = self.dot(self.r, z)  # Avoid calling custom dot func on non-master ranks.
+			self.rz0 = float(self.rz)
+			self.p   = z
+		else:
+			self.p = np.zeros_like(b)
 	def step(self):
 		"""Take a single step in the iteration. Results in .x, .i
 		and .err being updated. To solve the system, call step() in
@@ -41,16 +47,17 @@ class distributed_CG:
 		# Full vectors: p, Ap, x, r, z. Ap and z not in memory at the
 		# same time. Total memory cost: 4 vectors + 1 temporary = 5 vectors
 		Ap = self.A(self.p)
-		alpha = self.rz/self.dot(self.p, Ap)
-		self.x += alpha*self.p
-		self.r -= alpha*Ap
-		del Ap
-		z       = self.M(self.r)
-		next_rz = self.dot(self.r, z)
-		self.err = next_rz/self.rz0
-		beta = next_rz/self.rz
-		self.rz = next_rz
-		self.p  = z + beta*self.p
+		if self.is_master:  # The rest of the CG iteration is done by the master alone.
+			alpha = self.rz/self.dot(self.p, Ap)
+			self.x += alpha*self.p
+			self.r -= alpha*Ap
+			del Ap
+			z       = self.M(self.r)
+			next_rz = self.dot(self.r, z)
+			self.err = next_rz/self.rz0
+			beta = next_rz/self.rz
+			self.rz = next_rz
+			self.p  = z + beta*self.p
 		self.i += 1
 	def save(self, fname):
 		"""Save the volatile internal parameters to hdf file fname. Useful

--- a/src/python/solvers/comp_sep_solvers.py
+++ b/src/python/solvers/comp_sep_solvers.py
@@ -15,6 +15,7 @@ from src.python.utils.math_operations import alm_to_map, alm_to_map_adjoint, alm
     alm_complex2real, gaussian_random_alm, project_alms, almxfl, _inplace_prod_add,\
     _inplace_prod, _inplace_prod_scalar
 from src.python.solvers.dense_matrix_math import DenseMatrix
+from src.python.solvers.CG_driver import distributed_CG
 import src.python.solvers.preconditioners as preconditioners
 
 
@@ -501,9 +502,9 @@ class CompSepSolver:
         # Define dot-product for residual which returns 1.0 for non-master ranks (avoids warnings).
         mydot = lambda a,b: np.dot(a.flatten(),b.flatten()) if a.size > 0 else 1.0
         if M is None:
-            CG_solver = utils.CG(LHS, RHS, dot=mydot, x0=x0)
+            CG_solver = distributed_CG(LHS, RHS, dot=mydot, x0=x0)
         else:
-            CG_solver = utils.CG(LHS, RHS, dot=mydot, x0=x0, M=M)
+            CG_solver = distributed_CG(LHS, RHS, dot=mydot, x0=x0, M=M)
         self.CG_residuals = np.zeros((max_iter))
         if x_true is not None:
             # self.x_true_allcomps = self.CompSep_comm.allgather()

--- a/src/python/solvers/comp_sep_solvers.py
+++ b/src/python/solvers/comp_sep_solvers.py
@@ -511,9 +511,9 @@ class CompSepSolver:
         # Define dot-product for residual which returns 1.0 for non-master ranks (avoids warnings).
         mydot = lambda a,b: np.dot(a.flatten(),b.flatten()) if a.size > 0 else 1.0
         if M is None:
-            CG_solver = distributed_CG(LHS, RHS, dot=mydot, x0=x0)
+            CG_solver = distributed_CG(LHS, RHS, master, dot=mydot, x0=x0)
         else:
-            CG_solver = distributed_CG(LHS, RHS, dot=mydot, x0=x0, M=M)
+            CG_solver = distributed_CG(LHS, RHS, master, dot=mydot, x0=x0, M=M)
         self.CG_residuals = np.zeros((max_iter))
         if x_true is not None:
             # self.x_true_allcomps = self.CompSep_comm.allgather()

--- a/src/python/solvers/preconditioners.py
+++ b/src/python/solvers/preconditioners.py
@@ -240,17 +240,15 @@ class JointPreconditioner:
 
         a_array_out = a_array.copy()
         for icomp in range(self.compsep.ncomp):
-            idx_start = self.compsep.alm_start_idx_per_comp[icomp]
-            idx_stop = self.compsep.alm_start_idx_per_comp[icomp+1]
             comp_lmax = self.compsep.lmax_per_comp[icomp]
 
-            # Convert input real alm array to complex
-            a_alm_complex = alm_real2complex(a_array[:,idx_start:idx_stop], comp_lmax)
-
-            # Apply the preconditioner (divide by the pre-calculated diagonal of A)
-            a_alm_complex /= self.A_diag_list[icomp]
+            if self.compsep.params.CG_real_alm_mode:
+                a_array_out[icomp] = alm_real2complex(a_array_out[icomp], comp_lmax)
             
-            # Convert back to real alm array and return
-            a_array_out[:,idx_start:idx_stop] = alm_complex2real(a_alm_complex, comp_lmax)
+            # Apply the already calculated diagonal preconditioner.
+            a_array_out[icomp] /= self.A_diag_list[icomp]
+
+            if self.compsep.params.CG_real_alm_mode:
+                a_array_out[icomp] = alm_complex2real(a_array_out[icomp], comp_lmax)
         
         return a_array_out

--- a/src/python/solvers/preconditioners.py
+++ b/src/python/solvers/preconditioners.py
@@ -6,7 +6,8 @@ import typing
 from numpy.typing import NDArray
 from pixell import curvedsky
 from copy import deepcopy
-from src.python.utils.math_operations import alm_to_map, alm_to_map_adjoint, alm_real2complex, alm_complex2real
+from src.python.utils.math_operations import alm_to_map, alm_to_map_adjoint, alm_real2complex,\
+    alm_complex2real, _inplace_prod
 
 if typing.TYPE_CHECKING:  # Only import when performing type checking, avoiding circular import during normal runtime.
     from src.python.solvers.comp_sep_solvers import CompSepSolver
@@ -248,7 +249,7 @@ class JointPreconditioner:
                 a_array_out[icomp] = alm_real2complex(a_array_out[icomp], comp_lmax)
             
             # Apply the already calculated diagonal preconditioner.
-            a_array_out[icomp] *= self.A_diag_inv_list[icomp]
+            _inplace_prod(a_array_out[icomp], self.A_diag_inv_list[icomp])
 
             if self.compsep.params.CG_real_alm_mode:
                 a_array_out[icomp] = alm_complex2real(a_array_out[icomp], comp_lmax)

--- a/src/python/utils/math_operations.py
+++ b/src/python/utils/math_operations.py
@@ -13,19 +13,63 @@ import logging
 import os
 from math import sqrt
 from numba import njit, prange
+from scipy.linalg import blas as blas_wrapper
 
 
-###### GENERAL MATH STUFF ###########
+###### NUMPY REPLACEMENTS ######
+# Collection of Numba functions and BLAS wrappers for simply array manipulation.
+# These exist because 1. Numpy is in threaded, which is a problem on the comp-sep module which
+# has a lot of cores availabe, and 2. Certain Numpy operations create copies, these functions do not.
 
-@njit(cache=True, fastmath=True, parallel=True)
-def _inplace_prod_add(arr_main, arr_add, float_mult):
-    len = arr_main.size
-    assert(arr_main.ndim == 1)
+AXPY_ROUTINES = {
+    np.dtype('float32'): blas_wrapper.saxpy,
+    np.dtype('float64'): blas_wrapper.daxpy,
+    np.dtype('complex64'): blas_wrapper.caxpy,
+    np.dtype('complex128'): blas_wrapper.zaxpy,
+}
+def inplace_axpy(inplace_array, add_array, multiply_value):
+    """`inplace_array += add_array*multiply_value`. Performs in-place scaled vector addition using
+    BLAS AXPY routines. Support f32, 64, c64, and c128 data types, but all arguments must match.
+    """
+    if inplace_array.size == 0: return
+    assert(inplace_array.shape == add_array.shape)
+    assert(inplace_array.dtype == add_array.dtype)
+    assert(inplace_array.ndim == add_array.ndim)
+    # assert(inplace_array.ndim == 1)
+    # Select the Correct BLAS Routine
+    axpy_func = AXPY_ROUTINES[inplace_array.dtype]
+    # axpy_func(add_array, inplace_array, a=multiply_value)
+    axpy_func(x=add_array, y=inplace_array, n=inplace_array.size, a=multiply_value)
+
+
+@njit(fastmath=True, parallel=True)
+def _inplace_scale_add(arr_main, arr_add, float_mult):
+    # assert(arr_main.ndim == 1)
     assert(arr_main.shape==arr_add.shape)
-    for i in prange(len):
-        arr_main[i] += arr_add[i]*float_mult
+    flat1 = arr_main.ravel()
+    flat2 = arr_add.ravel()
+    for i in prange(arr_main.size):
+        flat1[i] = flat1[i]*float_mult + flat2[i]
 
-@njit(cache=True, fastmath=True, parallel=True)
+@njit(fastmath=True)
+def _inplace_prod_add_serial(arr_main, arr_add, float_mult):
+    # assert(arr_main.ndim == 1)
+    assert(arr_main.shape==arr_add.shape)
+    flat1 = arr_main.ravel()
+    flat2 = arr_add.ravel()
+    for i in range(arr_main.size):
+        flat1[i] += flat2[i]*float_mult
+
+@njit(fastmath=True, parallel=True)
+def _inplace_prod_add(arr_main, arr_add, float_mult):
+    # assert(arr_main.ndim == 1)
+    assert(arr_main.shape==arr_add.shape)
+    flat1 = arr_main.ravel()
+    flat2 = arr_add.ravel()
+    for i in prange(arr_main.size):
+        flat1[i] += flat2[i]*float_mult
+
+@njit(fastmath=True, parallel=True)
 def _inplace_prod(arr_main, arr_prod):
     len = arr_main.size
     assert(arr_main.ndim == 1)
@@ -33,13 +77,74 @@ def _inplace_prod(arr_main, arr_prod):
     for i in prange(len):
         arr_main[i] *= arr_prod[i]
 
-@njit(cache=True, fastmath=True, parallel=True)
+@njit(fastmath=True, parallel=True)
 def _inplace_prod_scalar(arr_main, scalar_prod):
     len = arr_main.size
     assert(arr_main.ndim == 1)
     for i in prange(len):
         arr_main[i] *= scalar_prod
 
+@njit(fastmath=True, parallel=True)
+def _dot(arr1, arr2):
+    len = arr1.size
+    res = 0.0
+    flat1 = arr1.ravel()
+    flat2 = arr2.ravel()
+    for i in prange(len):
+        res += flat1[i]*flat2[i]
+    return res
+
+
+@njit(fastmath=True, parallel=True)
+def _dot_complex_alm_1D_arrays(alm1: NDArray, alm2: NDArray, lmax: int) -> NDArray:
+    """ Function calculating the dot product of two alms, given that they follow the Healpy standard,
+        where alms are represented as complex numbers, but with the conjugate 'negative' ms missing.
+    """
+    return np.sum((alm1[:lmax]*alm2[:lmax]).real) + np.sum((alm1[lmax:]*np.conj(alm2[lmax:])).real*2)
+
+
+###### ALM-LIST FUNCTIONS ######
+# These functions are common array operations, but made to work on the alm-lists, which are
+# lists of arrays, with each array being the alms of a certain component.
+
+def inplace_almlist_add_scaled_array(list_inplace, list_other, value):
+    """ `list_inplace += value*list_other`
+    """
+    for i in range(len(list_inplace)):
+        _inplace_prod_add(list_inplace[i], list_other[i], value)
+
+def inplace_almlist_scale_and_add(list_inplace, list_other, value):
+    """ `list_inplace = value*list_inplace + list_other`
+    """
+    for i in range(len(list_inplace)):
+        _inplace_scale_add(list_inplace[i], list_other[i], value)
+
+def almlist_dot_complex(alm_list1, alm_list2):
+    """ `dot(alm_list1, alm_list2)`. Calculates the correct dot product between two alm lists where
+        the alms follow the Healpy convention of not storing negative ms.
+    """
+    res = 0.0
+    for i in range(len(alm_list1)):
+        npol, nalm = alm_list1[i].shape
+        lmax = hp.Alm.getlmax(nalm)
+        for ipol in range(npol):
+            res += _dot_complex_alm_1D_arrays(alm_list1[i][ipol], alm_list2[i][ipol], lmax)
+    return res
+
+def almlist_dot_real(alm_list1, alm_list2):
+    """ `list_inplace = value*list_inplace + list_other`
+    """
+    res = 0.0
+    for i in range(len(alm_list1)):
+        npol, nalm = alm_list1[i].shape
+        for ipol in range(npol):
+            res += _dot(alm_list1[i][ipol], alm_list2[i][ipol])
+    return res
+
+
+
+
+###### GENERAL MATH STUFF ######
 
 def forward_rfft(data:NDArray[np.floating], nthreads:int = 1):
     """ Forward real Fourier transform, equivalent to scipy.fft.rfft.


### PR DESCRIPTION
- Re-implemented the complex alm representation, because converting to and from reals was actually a pretty big overhead. The real-representation is still available for debugging purposes.
- The compsep CG solver now works exclusively on the alm-lists, and do not convert them to and from compact 1D arrays at the beginning and end of each LHS call, reducing copying and memory overhead.
- The above point required copying and modifying the CG implementation we were using from pixell.
- Various optimizations of simple array operations.